### PR TITLE
Trim template's email subject when it's too long

### DIFF
--- a/src/iris_frontend/static/css/iris.css
+++ b/src/iris_frontend/static/css/iris.css
@@ -878,6 +878,14 @@ table.dataTable thead .sorting_asc {
   height: 215px; /* less 20px for subject line */
 }
 
+.template-notification .notification-email-subject {
+  overflow: hidden;
+  height: 20px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 3px;
+}
+
 .template-notification .notification-header {
   background: #f0f3f6;
   color: #333;

--- a/src/iris_frontend/templates/template.html
+++ b/src/iris_frontend/templates/template.html
@@ -124,7 +124,7 @@
   <!--// view-only template-->
     <div class="notification-header">{{key}}</div>
     {{#isEqual key 'email'}}
-    <p>{{getValForKey this key 'subject' true}}</p>
+    <p class="notification-email-subject">{{getValForKey this key 'subject' true}}</p>
     {{/isEqual}}
     <pre class="notification-body">{{getValForKey this key 'body' true}}</pre>
   </div>

--- a/src/iris_frontend/templates/template.html
+++ b/src/iris_frontend/templates/template.html
@@ -124,7 +124,7 @@
   <!--// view-only template-->
     <div class="notification-header">{{key}}</div>
     {{#isEqual key 'email'}}
-    <p class="notification-email-subject">{{getValForKey this key 'subject' true}}</p>
+    <p class="notification-email-subject" title="{{getValForKey this key 'subject' true}}">{{getValForKey this key 'subject' true}}</p>
     {{/isEqual}}
     <pre class="notification-body">{{getValForKey this key 'body' true}}</pre>
   </div>


### PR DESCRIPTION
Avoid breaking the form when subject is too long, which happens in several cases.