### PR TITLE
Enable removal of tracking settings

### DIFF
--- a/src/iris_frontend/static/js/iris.js
+++ b/src/iris_frontend/static/js/iris.js
@@ -466,6 +466,10 @@ iris = {
       // collect data for tracking templates
 
       if ($trackingEl.length) {
+        if ($trackingEl.find('.template-notification').length == 0) {
+            return true;
+        }
+
         model.tracking_type = $trackingEl.find('#tracking-type').val();
         model.tracking_key = $trackingEl.find('#tracking-key').val();
 


### PR DESCRIPTION
When you click the 'X' next to each tracking template that might
exist, delete the tracking settings for this plan.